### PR TITLE
Mark package:flutter stack frames as not in-app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * Update README with new flutter_sentry version.
+* Filter `package:flutter` stack trace frames by default.
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Unreleased
 
-* Update README with new flutter_sentry version.
+* Update README with new `flutter_sentry` version.
 * Filter `package:flutter` stack trace frames by default.
+* Remove the use of deprecated method `getFlutterEngine`.
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.2.1
 
 * Update README with new `flutter_sentry` version.
 * Filter `package:flutter` stack trace frames by default.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
    ```yaml
    dependencies:
-     flutter_sentry: ^0.2.0
+     flutter_sentry: ^0.2.1
    ```
 
 2. Find out a DSN value from Sentry.io and add it to native platforms:

--- a/android/src/main/kotlin/org/dasfoo/flutter_sentry/FlutterSentryPlugin.kt
+++ b/android/src/main/kotlin/org/dasfoo/flutter_sentry/FlutterSentryPlugin.kt
@@ -1,7 +1,6 @@
 package org.dasfoo.flutter_sentry
 
-import android.nfc.FormatException
-import androidx.annotation.NonNull;
+import androidx.annotation.NonNull
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -10,12 +9,11 @@ import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry.Registrar
 
 
-
 /** FlutterSentryPlugin */
-public class FlutterSentryPlugin: FlutterPlugin, MethodCallHandler {
+class FlutterSentryPlugin: FlutterPlugin, MethodCallHandler {
   override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-    val channel = MethodChannel(flutterPluginBinding.getFlutterEngine().getDartExecutor(), "flutter_sentry")
-    channel.setMethodCallHandler(FlutterSentryPlugin());
+    val channel = MethodChannel(flutterPluginBinding.binaryMessenger, "flutter_sentry")
+    channel.setMethodCallHandler(FlutterSentryPlugin())
   }
 
   // This static function is optional and equivalent to onAttachedToEngine. It supports the old
@@ -29,6 +27,7 @@ public class FlutterSentryPlugin: FlutterPlugin, MethodCallHandler {
   // in the same class.
   companion object {
     @JvmStatic
+    @Suppress("unused")
     fun registerWith(registrar: Registrar) {
       val channel = MethodChannel(registrar.messenger(), "flutter_sentry")
       channel.setMethodCallHandler(FlutterSentryPlugin())

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -82,7 +82,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.0"
+    version: "0.2.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/lib/flutter_sentry.dart
+++ b/lib/flutter_sentry.dart
@@ -132,8 +132,26 @@ class FlutterSentry {
       breadcrumbs: breadcrumbs.breadcrumbs.toList(),
       deviceContext: _deviceContext,
     );
-    return _sentry.capture(event: event);
+    return _sentry.capture(event: event, stackFrameFilter: stackFrameFilter);
   }
+
+  /// Filter for stack trace frames, applied after `Frame` objects are converted
+  /// to JSON representation but before they are sent to Sentry. See
+  /// [SentryClient.capture] for more information.
+  List<Map<String, dynamic>> Function(List<Map<String, dynamic>>)
+      stackFrameFilter = defaultStackFrameFilter;
+
+  /// Default filtering for Sentry JSON stack frames with Flutter-oriented
+  /// implementation, such as marking Flutter part of stacktrace as framework
+  /// stack trace to unclutter Sentry.io interface.
+  static List<Map<String, dynamic>> defaultStackFrameFilter(
+          List<Map<String, dynamic>> stack) =>
+      stack
+          .map<Map<String, dynamic>>((frame) =>
+              frame['abs_path'].toString().startsWith('package:flutter/')
+                  ? (frame..['in_app'] = false)
+                  : frame)
+          .toList();
 
   /// Return the configured instance of [FlutterSentry] after it has been
   /// initialized with [initialize] method, or `null` if the instance has not

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_sentry
 description: Sentry.io error reporting plugin for Flutter, offering tight integration with Flutter and native code.
-version: 0.2.0
+version: 0.2.1
 homepage: https://github.com/dasfoo/flutter_sentry
 
 environment:

--- a/test/flutter_sentry_test.dart
+++ b/test/flutter_sentry_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_sentry/flutter_sentry.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('defaultStackFrameFilter', () {
+    test('marks frames from "flutter" package as not in_app', () {
+      expect(
+        FlutterSentry.defaultStackFrameFilter([
+          {'abs_path': 'package:tedious_monsters/alarm.dart'},
+          {'abs_path': 'package:flutter_helper/index.dart'},
+          {'abs_path': 'package:flutter/flutter.dart'},
+          {'abs_path': 'package:flutter/init.dart'},
+          {'abs_path': 'main.dart'},
+        ]),
+        [
+          {'abs_path': 'package:tedious_monsters/alarm.dart'},
+          {'abs_path': 'package:flutter_helper/index.dart'},
+          {'in_app': false, 'abs_path': 'package:flutter/flutter.dart'},
+          {'in_app': false, 'abs_path': 'package:flutter/init.dart'},
+          {'abs_path': 'main.dart'},
+        ],
+      );
+    });
+  });
+}


### PR DESCRIPTION
Affects how Sentry.io shows them (default hidden).