### PR TITLE
Fix #38 Kotlin plugin initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Reliably cause a native crash on Android.
+- Fix #38 `kotlin.UninitializedPropertyAccessException` in Android plugin
 - Support release health tracking for iOS. This was previously added for Android in 0.4.0
 
 ## 0.4.3


### PR DESCRIPTION
* use same initialization for old and new embedding
* set instance channel to prevent kotlin.UninitializedPropertyAccessException